### PR TITLE
Added ephem to the list of required modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas==2.2.2
 numpy
 swisseph
 scikit-learn
+ephem


### PR DESCRIPTION
Hi, the `requirements.txt` file missed out on the `ephem` module  - [link](https://pypi.org/project/ephem/). I have added the same.